### PR TITLE
chore: update import statements to use standard paths in ESLint configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
 import { FlatCompat } from "@eslint/eslintrc";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
-import dirname from "node:path";
-import fileURLToPath from "node:url";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
This pull request updates the import statements in the `eslint.config.mjs` file to use destructured imports for improved readability and consistency.

Codebase improvements:

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L3-R4): Changed the imports for `dirname` and `fileURLToPath` to use destructured imports from the `path` and `url` modules, respectively.