### PR TITLE
chore: update unicorn/import-style rule in ESLint configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,15 @@ const eslintConfig = [
           case: "kebabCase",
         },
       ],
+      "unicorn/import-style": [
+        "error", {
+          "extendsDefaultStyles": false,
+          "checkImport": false,
+          "checkDynamicImport": false,
+          "checkExportFrom": true,
+          "checkRequire": false,
+        }
+      ]
     },
   }),
   eslintPluginUnicorn.configs.recommended,


### PR DESCRIPTION
This pull request updates the ESLint configuration to enforce a specific import style using the `unicorn/import-style` rule.

### ESLint Configuration Update:
* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R30-R38): Added the `unicorn/import-style` rule with customized options to enforce import/export style consistency. The rule disables checks for default styles, dynamic imports, and `require` statements but enables checks for `export from` syntax.