### PR TITLE
chore: fix typo in unicorn/import-style rule configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ const eslintConfig = [
       ],
       "unicorn/import-style": [
         "error", {
-          "extendsDefaultStyles": false,
+          "extendDefaultStyles": false,
           "checkImport": false,
           "checkDynamicImport": false,
           "checkExportFrom": true,


### PR DESCRIPTION
This pull request includes a minor correction to the ESLint configuration. The change fixes a typo in the `unicorn/import-style` rule options.

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L32-R32): Corrected the property name from `extendsDefaultStyles` to `extendDefaultStyles` in the `unicorn/import-style` rule configuration.