### PR TITLE
chore: disable unicorn/import-style rule in ESLint configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,15 +27,7 @@ const eslintConfig = [
           case: "kebabCase",
         },
       ],
-      "unicorn/import-style": [
-        "error", {
-          "extendDefaultStyles": false,
-          "checkImport": false,
-          "checkDynamicImport": false,
-          "checkExportFrom": true,
-          "checkRequire": false,
-        }
-      ]
+      "unicorn/import-style": "off"
     },
   }),
   eslintPluginUnicorn.configs.recommended,


### PR DESCRIPTION
This pull request modifies the ESLint configuration in `eslint.config.mjs` to simplify the rules for the `unicorn/import-style` plugin.

### ESLint configuration changes:

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L30-R30): The `unicorn/import-style` rule has been turned off, replacing the previous configuration that included multiple options such as `extendDefaultStyles`, `checkImport`, and `checkExportFrom`.