### PR TITLE
fix: update import statements for path and url modules to use node: prefix

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,10 @@
 import { FlatCompat } from "@eslint/eslintrc";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
-import { dirname } from "path";
-import { fileURLToPath } from "url";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __dirname = path.dirname(__filename);
 
 const compat = new FlatCompat({
   baseDirectory: __dirname,


### PR DESCRIPTION
This pull request includes a small update to the `eslint.config.mjs` file. It replaces individual imports of `dirname` and `fileURLToPath` from `path` and `url` with consolidated imports from `node:path` and `node:url`, improving clarity and aligning with modern module conventions.